### PR TITLE
add dialog.cfg to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ export_presets.cfg
 # Mono-specific ignores
 .mono/
 data_*/
+
+# Godot Dialog Manager Ignores
+dialogue.cfg


### PR DESCRIPTION
The dialogue.cfg file is dynamically generated as far as I can tell. We can ignore it