### PR TITLE
Prevents game_state from being null

### DIFF
--- a/Scripts/game_state.gd
+++ b/Scripts/game_state.gd
@@ -41,6 +41,7 @@ func _add_global_item(resource, name, display_name):
 	var item = load(resource).new()
 	item.display_name = display_name
 	item.name = name
+	item.game_state = self
 	_global_items[name] = item
 	return item
 


### PR DESCRIPTION
 - as these actors are not part of the tree, they don't get the
   chance to load the game_state. Instead, set it at creation
   time